### PR TITLE
Add comprehensive tests for IDB API Layer

### DIFF
--- a/tests/confusion_pairs.spec.ts
+++ b/tests/confusion_pairs.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await window.db.delete();
+    await window.db.open();
+  });
+});
+
+test('confusion pairs: recording and retrieval', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const sid = await window.idbApiLayer.createStudyset({ title: "S", draft: false });
+    await window.idbApiLayer.createTerms(sid, [
+        { term: "t1", def: "d1", sortOrder: 0, createdAt: "", updatedAt: "", studysetId: sid },
+        { term: "t2", def: "d2", sortOrder: 1, createdAt: "", updatedAt: "", studysetId: sid },
+        { term: "t3", def: "d3", sortOrder: 2, createdAt: "", updatedAt: "", studysetId: sid }
+    ]);
+    const terms = await window.idbApiLayer.getTermsByStudysetId(sid);
+    const tid1 = terms[0].id;
+    const tid2 = terms[1].id;
+    const tid3 = terms[2].id;
+
+    const rnISOString = (new Date()).toISOString();
+
+    // Record some confusions
+    await window.idbApiLayer.recordConfusionPairs([
+        { termId: tid1, confusedTermId: tid2, answeredWith: "def", confusedCountIncrease: 5, confusedAt: rnISOString },
+        { termId: tid1, confusedTermId: tid3, answeredWith: "def", confusedCountIncrease: 2, confusedAt: rnISOString },
+    ]);
+
+    // Record another confusion with same pair to update count
+    await window.idbApiLayer.recordConfusionPairs([
+        { termId: tid1, confusedTermId: tid2, answeredWith: "def", confusedCountIncrease: 1, confusedAt: rnISOString },
+    ]);
+
+    const topForT1 = await window.idbApiLayer.getTopConfusionPairs(tid1, { confusedTerm: true });
+    const reverseForT2 = await window.idbApiLayer.getTopReverseConfusionPairs(tid2, { term: true });
+
+    return { topForT1, reverseForT2 };
+  });
+
+  expect(result.topForT1).toHaveLength(2);
+  expect(result.topForT1[0].confusedTermId).toBe(result.topForT1[0].confusedTerm?.id);
+  expect(result.topForT1[0].confusedCount).toBe(6); // 5 + 1
+  expect(result.topForT1[1].confusedCount).toBe(2);
+
+  expect(result.reverseForT2).toHaveLength(1);
+  expect(result.reverseForT2[0].termId).toBe(result.reverseForT2[0].term?.id);
+  expect(result.reverseForT2[0].confusedCount).toBe(6);
+});

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await window.db.delete();
+    await window.db.open();
+  });
+});
+
+test('processAndUpdateTermImage, getImageObjectUrl, removeTermImage', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    // Generate a 1x1 red pixel image as a Blob
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const ctx = canvas.getContext('2d');
+    ctx!.fillStyle = 'red';
+    ctx!.fillRect(0, 0, 1, 1);
+    const blob = await new Promise<Blob>(res => canvas.toBlob(b => res(b!), 'image/png'));
+
+    const sid = await window.idbApiLayer.createStudyset({ title: "Image Test", draft: false });
+    await window.idbApiLayer.createTerms(sid, [
+      { term: "t1", def: "d1", sortOrder: 0, createdAt: "", updatedAt: "", studysetId: sid }
+    ]);
+    const terms = await window.idbApiLayer.getTermsByStudysetId(sid);
+    const termId = terms[0].id;
+
+    // Add image to term
+    await window.idbLayerImg.processAndUpdateTermImage(termId, false, blob);
+    let term = await window.idbApiLayer.getTermById(termId, { termImageUrl: true });
+    const termImageUrl = term?.termImageUrl;
+
+    // Verify it's in the DB
+    const imageCountInDb = await window.db.images.count();
+
+    // Add image to definition
+    await window.idbLayerImg.processAndUpdateTermImage(termId, true, blob);
+    term = await window.idbApiLayer.getTermById(termId, { defImageUrl: true });
+    const defImageUrl = term?.defImageUrl;
+    const imageCountInDbAfterBoth = await window.db.images.count();
+
+    // Remove term image
+    await window.idbLayerImg.removeTermImage(termId, false);
+    term = await window.idbApiLayer.getTermById(termId, { termImageUrl: true });
+    const termImageUrlAfterRemove = term?.termImageUrl;
+    const imageCountInDbAfterRemoveOne = await window.db.images.count();
+
+    return {
+        termImageUrl,
+        defImageUrl,
+        imageCountInDb,
+        imageCountInDbAfterBoth,
+        termImageUrlAfterRemove,
+        imageCountInDbAfterRemoveOne
+    };
+  });
+
+  expect(result.termImageUrl).not.toBeNull();
+  expect(result.defImageUrl).not.toBeNull();
+  expect(result.imageCountInDb).toBe(1);
+  expect(result.imageCountInDbAfterBoth).toBe(2);
+  expect(result.termImageUrlAfterRemove).toBeNull();
+  expect(result.imageCountInDbAfterRemoveOne).toBe(1);
+});
+
+test('processImage directly', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 100;
+    canvas.height = 100;
+    const ctx = canvas.getContext('2d');
+    ctx!.fillStyle = 'blue';
+    ctx!.fillRect(0, 0, 100, 100);
+    const blob = await new Promise<Blob>(res => canvas.toBlob(b => res(b!), 'image/png'));
+
+    const processedBlob = await window.idbLayerImg.processImage(blob, 50, 50, 0.5);
+
+    // Check dimensions by loading processed blob back into an image
+    return await new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => resolve({ width: img.width, height: img.height });
+        img.src = URL.createObjectURL(processedBlob);
+    });
+  });
+
+  expect(result.width).toBeLessThanOrEqual(50);
+  expect(result.height).toBeLessThanOrEqual(50);
+});
+
+test('deleteImages and effect of deleteTerms on images', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const blob = await new Promise<Blob>(res => canvas.toBlob(res!, 'image/png'));
+
+    const sid = await window.idbApiLayer.createStudyset({ title: "S", draft: false });
+    await window.idbApiLayer.createTerms(sid, [
+        { term: "t1", def: "d1", sortOrder: 0, createdAt: "", updatedAt: "", studysetId: sid }
+    ]);
+    const terms = await window.idbApiLayer.getTermsByStudysetId(sid);
+    const tid = terms[0].id;
+    await window.idbLayerImg.processAndUpdateTermImage(tid, false, blob);
+    await window.idbLayerImg.processAndUpdateTermImage(tid, true, blob);
+
+    const countBefore = await window.db.images.count();
+    await window.idbApiLayer.deleteTerms([tid]);
+    const countAfter = await window.db.images.count();
+
+    return { countBefore, countAfter };
+  });
+
+  expect(result.countBefore).toBe(2);
+  expect(result.countAfter).toBe(0);
+});

--- a/tests/practice_tests.spec.ts
+++ b/tests/practice_tests.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await window.db.delete();
+    await window.db.open();
+  });
+});
+
+test('practice tests: recording and retrieval in studyset', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const sid = await window.idbApiLayer.createStudyset({ title: "S", draft: false });
+
+    // Record two practice tests at different timestamps
+    const time1 = "2024-01-01T10:00:00.000Z";
+    const time2 = "2024-01-02T10:00:00.000Z";
+
+    await window.idbApiLayer.recordPracticeTest({
+        studysetId: sid,
+        timestamp: time1,
+        questionsCorrect: 8,
+        questionsTotal: 10
+    });
+
+    await window.idbApiLayer.recordPracticeTest({
+        studysetId: sid,
+        timestamp: time2,
+        questionsCorrect: 9,
+        questionsTotal: 10
+    });
+
+    const studysetWithTests = await window.idbApiLayer.getStudysetById(sid, { practiceTests: true });
+    return { studysetWithTests };
+  });
+
+  expect(result.studysetWithTests?.practiceTests).toHaveLength(2);
+  // Should be sorted by timestamp descending
+  expect(result.studysetWithTests?.practiceTests?.[0].timestamp).toBe("2024-01-02T10:00:00.000Z");
+  expect(result.studysetWithTests?.practiceTests?.[1].timestamp).toBe("2024-01-01T10:00:00.000Z");
+});

--- a/tests/progress.spec.ts
+++ b/tests/progress.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await window.db.delete();
+    await window.db.open();
+  });
+});
+
+test('updateTermProgress: initial and update', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const sid = await window.idbApiLayer.createStudyset({ title: "S", draft: false });
+    await window.idbApiLayer.createTerms(sid, [
+        { term: "t1", def: "d1", sortOrder: 0, createdAt: "", updatedAt: "", studysetId: sid }
+    ]);
+    const terms = await window.idbApiLayer.getTermsByStudysetId(sid);
+    const tid = terms[0].id;
+
+    const rnISOString = (new Date()).toISOString();
+
+    // Initial progress
+    await window.idbApiLayer.updateTermProgress([{
+        termId: tid,
+        termReviewedAt: rnISOString,
+        termCorrectIncrease: 1,
+        termLeitnerSystemBox: 1
+    }]);
+
+    let termWithProgress = await window.idbApiLayer.getTermById(tid, { progress: true, progressHistory: true });
+    const p1 = termWithProgress?.progress;
+    const h1 = termWithProgress?.progressHistory;
+
+    // Update progress
+    await window.idbApiLayer.updateTermProgress([{
+        termId: tid,
+        defReviewedAt: rnISOString,
+        defCorrectIncrease: 2,
+        defLeitnerSystemBox: 2
+    }]);
+
+    termWithProgress = await window.idbApiLayer.getTermById(tid, { progress: true, progressHistory: true });
+    const p2 = termWithProgress?.progress;
+    const h2 = termWithProgress?.progressHistory;
+
+    return { p1, h1, p2, h2 };
+  });
+
+  expect(result.p1?.termCorrectCount).toBe(1);
+  expect(result.p1?.termReviewCount).toBe(1);
+  expect(result.p1?.termLeitnerSystemBox).toBe(1);
+  expect(result.h1).toHaveLength(1);
+
+  expect(result.p2?.termCorrectCount).toBe(1);
+  expect(result.p2?.defCorrectCount).toBe(2);
+  expect(result.p2?.defReviewCount).toBe(1);
+  expect(result.p2?.defLeitnerSystemBox).toBe(2);
+  expect(result.p2?.termLeitnerSystemBox).toBe(1);
+  expect(result.h2).toHaveLength(2);
+});

--- a/tests/studysets.spec.ts
+++ b/tests/studysets.spec.ts
@@ -1,11 +1,17 @@
 import { test, expect } from '@playwright/test';
 
-test('create, view, update, & delete studyset', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   await page.goto('/');
+  await page.evaluate(async () => {
+    await window.db.delete();
+    await window.db.open();
+  });
+});
 
+test('create, view, update, & delete studyset', async ({ page }) => {
   const result = await page.evaluate(async () => {
     const id = await window.idbApiLayer.createStudyset({
-      title: "",
+      title: "Initial Title",
       draft: true
     });
 
@@ -13,29 +19,75 @@ test('create, view, update, & delete studyset', async ({ page }) => {
 
     await window.idbApiLayer.updateStudyset({
       id,
-      title: "",
+      title: "Updated Title",
       draft: false
     });
 
-    let updated1 = await window.idbApiLayer.getStudysetById(id);
+    let updated = await window.idbApiLayer.getStudysetById(id);
 
-    await window.idbApiLayer.updateStudyset({
-      id,
-      title: "New Title!!!",
-      draft: false
-    });
+    await window.idbApiLayer.deleteStudyset(id);
+    let deleted = await window.idbApiLayer.getStudysetById(id);
 
-    let updated2 = await window.idbApiLayer.getStudysetById(id);
-
-    return { studyset, updated1, updated2 };
+    return { studyset, updated, deleted };
   });
 
-  expect(result.studyset?.title).toBe("");
+  expect(result.studyset?.title).toBe("Initial Title");
   expect(result.studyset?.draft).toBe(true);
 
-  expect(result.updated1?.title).toBe("Untitled Studyset");
-  expect(result.updated1?.draft).toBe(false);
+  expect(result.updated?.title).toBe("Updated Title");
+  expect(result.updated?.draft).toBe(false);
 
-  expect(result.updated2?.title).toBe("New Title!!!");
-  expect(result.updated2?.draft).toBe(false);
+  expect(result.deleted).toBeNull();
+});
+
+test('getStudysetById with resolveProps', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const id = await window.idbApiLayer.createStudyset({
+      title: "Studyset with terms and tests",
+      draft: false
+    });
+
+    await window.idbApiLayer.createTerms(id, [
+      { term: "t1", def: "d1", sortOrder: 0, createdAt: "", updatedAt: "" },
+      { term: "t2", def: "d2", sortOrder: 1, createdAt: "", updatedAt: "" }
+    ]);
+
+    await window.idbApiLayer.recordPracticeTest({
+      studysetId: id,
+      timestamp: (new Date()).toISOString(),
+      questionsCorrect: 5,
+      questionsTotal: 10
+    });
+
+    let fullStudyset = await window.idbApiLayer.getStudysetById(id, {
+      terms: true,
+      practiceTests: true
+    });
+
+    return { fullStudyset };
+  });
+
+  expect(result.fullStudyset?.terms).toHaveLength(2);
+  expect(result.fullStudyset?.practiceTests).toHaveLength(1);
+});
+
+test('isTitleValid logic through create/updateStudyset', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const id1 = await window.idbApiLayer.createStudyset({
+      title: "   ", // All spaces
+      draft: false
+    });
+    const s1 = await window.idbApiLayer.getStudysetById(id1);
+
+    const id2 = await window.idbApiLayer.createStudyset({
+      title: "", // Empty but draft
+      draft: true
+    });
+    const s2 = await window.idbApiLayer.getStudysetById(id2);
+
+    return { s1, s2 };
+  });
+
+  expect(result.s1?.title).toBe("Untitled Studyset");
+  expect(result.s2?.title).toBe("");
 });

--- a/tests/terms.spec.ts
+++ b/tests/terms.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await window.db.delete();
+    await window.db.open();
+  });
+});
+
+test('create, update, and delete terms', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const sid = await window.idbApiLayer.createStudyset({ title: "S1", draft: false });
+
+    // Create terms
+    await window.idbApiLayer.createTerms(sid, [
+      { term: "t1", def: "d1", sortOrder: 0, createdAt: "", updatedAt: "", studysetId: sid },
+      { term: "t2", def: "d2", sortOrder: 1, createdAt: "", updatedAt: "", studysetId: sid }
+    ]);
+
+    let terms = await window.idbApiLayer.getTermsByStudysetId(sid);
+
+    // Update terms
+    const updatedTerms = terms.map(t => ({ ...t, term: t.term + " updated" }));
+    await window.idbApiLayer.updateTerms(updatedTerms);
+
+    let termsAfterUpdate = await window.idbApiLayer.getTermsByStudysetId(sid);
+
+    // Delete one term
+    await window.idbApiLayer.deleteTerms([terms[0].id]);
+    let termsAfterDelete = await window.idbApiLayer.getTermsByStudysetId(sid);
+
+    let singleTerm = await window.idbApiLayer.getTermById(terms[1].id);
+
+    return { terms, termsAfterUpdate, termsAfterDelete, singleTerm };
+  });
+
+  expect(result.terms).toHaveLength(2);
+  expect(result.termsAfterUpdate[0].term).toBe("t1 updated");
+  expect(result.termsAfterDelete).toHaveLength(1);
+  expect(result.termsAfterDelete[0].term).toBe("t2 updated");
+  expect(result.singleTerm?.term).toBe("t2 updated");
+});
+
+test('verify sortOrder in getTermsByStudysetId', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const sid = await window.idbApiLayer.createStudyset({ title: "S2", draft: false });
+
+    await window.idbApiLayer.createTerms(sid, [
+      { term: "last", def: "d", sortOrder: 10, createdAt: "", updatedAt: "", studysetId: sid },
+      { term: "first", def: "d", sortOrder: 0, createdAt: "", updatedAt: "", studysetId: sid },
+      { term: "middle", def: "d", sortOrder: 5, createdAt: "", updatedAt: "", studysetId: sid }
+    ]);
+
+    let terms = await window.idbApiLayer.getTermsByStudysetId(sid);
+    return { terms };
+  });
+
+  expect(result.terms[0].term).toBe("first");
+  expect(result.terms[1].term).toBe("middle");
+  expect(result.terms[2].term).toBe("last");
+});


### PR DESCRIPTION
I have added a comprehensive suite of tests for the IndexedDB API Layer. These tests cover all public methods and specific functionalities you requested:
- **Studysets**: Comprehensive CRUD operations, including `resolveProps` and title validation.
- **Terms**: Addition, editing, deletion, and verification of `sortOrder`.
- **Images**: Processing and associating images with terms/definitions, and their deletion.
- **Progress**: Tracking term progress and historical data.
- **Confusion Pairs**: Recording and retrieving the most common mistakes.
- **Practice Tests**: Recording results and ensuring they are correctly associated and sorted within studysets.

The tests are organized into functional files (`studysets.spec.ts`, `terms.spec.ts`, `images.spec.ts`, `progress.spec.ts`, `confusion_pairs.spec.ts`, `practice_tests.spec.ts`) and have been verified to pass using Playwright.

---
*PR created automatically by Jules for task [2194378088286218233](https://jules.google.com/task/2194378088286218233) started by @ehanahamed*